### PR TITLE
changes params for Sequel connection(for sqlite db)

### DIFF
--- a/lib/spree_admin_insights/engine.rb
+++ b/lib/spree_admin_insights/engine.rb
@@ -22,17 +22,13 @@ module SpreeAdminInsights
     config.to_prepare &method(:activate).to_proc
 
     config.after_initialize do
-      def connnection_configurations
-        configuration_hash = Rails.configuration.database_configuration[Rails.env].to_h
-        if configuration_hash['adapter'] == 'sqlite3'
-          configuration_hash.merge!({ adapter: 'sqlite' })
-        end
-        configuration_hash
-      end
+      configuration_hash = (ActiveRecord::Base.configurations[Rails.env] ||
+                            Rails.configuration.database_configuration[Rails.env]
+                            ).to_h
+      configuration_hash.merge!({ 'adapter' => 'sqlite' }) if(configuration_hash['adapter'] == 'sqlite3')
 
       # Connect to applications DB using ruby's Sequel wrapper
-      ::SpreeAdminInsights::ReportDb = Sequel.connect(connnection_configurations)
-
+      ::SpreeAdminInsights::ReportDb = Sequel.connect(configuration_hash)
     end
   end
 end

--- a/lib/spree_admin_insights/engine.rb
+++ b/lib/spree_admin_insights/engine.rb
@@ -22,8 +22,17 @@ module SpreeAdminInsights
     config.to_prepare &method(:activate).to_proc
 
     config.after_initialize do
+      def connnection_configurations
+        configuration_hash = Rails.configuration.database_configuration[Rails.env].to_h
+        if configuration_hash['adapter'] == 'sqlite3'
+          configuration_hash.merge!({ adapter: 'sqlite' })
+        end
+        configuration_hash
+      end
+
       # Connect to applications DB using ruby's Sequel wrapper
-      ::SpreeAdminInsights::ReportDb = Sequel.connect(Rails.configuration.database_configuration[Rails.env])
+      ::SpreeAdminInsights::ReportDb = Sequel.connect(connnection_configurations)
+
     end
   end
 end


### PR DESCRIPTION
#28 LoadError: cannot load such file -- sequel/adapters/sqlite3 (Sequel::AdapterNotFound) 
This exception here is due to different adapter names used by sqlite and Sequel for sqlite db.

As a fix we can modify params accordingly