### PR TITLE
fixed reports for postgres

### DIFF
--- a/app/reports/spree/best_selling_products_report.rb
+++ b/app/reports/spree/best_selling_products_report.rb
@@ -19,14 +19,14 @@ module Spree
       join(:spree_products___products, products__id: :variants__product_id).
       where(orders__state: 'complete').
       where(orders__completed_at: @start_date..@end_date). #filter by params
-      group(:variant_id).
+      group(:variant_id, :variants__sku, :products__name).
       order(sortable_sequel_expression)
     end
 
     def select_columns(dataset)
       dataset.select{[
         products__name.as(product_name),
-        Sequel.as(IF(STRCMP(variants__sku, ''), variants__sku, products__name), :sku),
+        Sequel.as(Sequel.lit("CASE variants.sku WHEN '' THEN products.name ELSE variants.sku END"), :sku),
         sum(quantity).as(sold_count)
       ]}
     end

--- a/app/reports/spree/cart_additions_report.rb
+++ b/app/reports/spree/cart_additions_report.rb
@@ -12,21 +12,21 @@ module Spree
 
     def generate
       SpreeAdminInsights::ReportDb[:spree_cart_events___cart_events].
-      join(:spree_variants___variants, id: :variant_id).
-      join(:spree_products___products, id: :product_id).
-      where(cart_events__activity: 'add').
-      where(cart_events__created_at: @start_date..@end_date).
-      group(:variant_id).
-      order(sortable_sequel_expression)
+        join(:spree_variants___variants, id: :variant_id).
+        join(:spree_products___products, id: :product_id).
+        where(cart_events__activity: 'add').
+        where(cart_events__created_at: @start_date..@end_date).
+        group(:variant_id, :variants__sku, :products__name).
+        order(sortable_sequel_expression)
     end
 
     def select_columns(dataset)
-      dataset.select{[
+      dataset.select { [
         products__name.as(product_name),
-        Sequel.as(IF(STRCMP(variants__sku, ''), variants__sku, products__name), :sku),
+        Sequel.as(Sequel.lit("CASE variants.sku WHEN '' THEN products.name ELSE variants.sku END"), :sku),
         Sequel.as(count(:products__name), :additions),
         Sequel.as(sum(cart_events__quantity), :quantity_change)
-      ]}
+      ] }
     end
   end
 end

--- a/app/reports/spree/cart_removals_report.rb
+++ b/app/reports/spree/cart_removals_report.rb
@@ -12,21 +12,21 @@ module Spree
 
     def generate
       SpreeAdminInsights::ReportDb[:spree_cart_events___cart_events].
-      join(:spree_variants___variants, id: :variant_id).
-      join(:spree_products___products, id: :product_id).
-      where(cart_events__activity: 'remove').
-      where(cart_events__created_at: @start_date..@end_date). #filter by params
-      group(:variant_id).
-      order(sortable_sequel_expression)
+        join(:spree_variants___variants, id: :variant_id).
+        join(:spree_products___products, id: :product_id).
+        where(cart_events__activity: 'remove').
+        where(cart_events__created_at: @start_date..@end_date).#filter by params
+        group(:variant_id, :variants__sku, :products__name).
+        order(sortable_sequel_expression)
     end
 
     def select_columns(dataset)
-      dataset.select{[
+      dataset.select { [
         products__name.as(product_name),
-        Sequel.as(IF(STRCMP(variants__sku, ''), variants__sku, products__name), :sku),
+        Sequel.as(Sequel.lit("CASE variants.sku WHEN '' THEN products.name ELSE variants.sku END"), :sku),
         Sequel.as(count(:products__name), :removals),
         Sequel.as(sum(cart_events__quantity), :quantity_change)
-      ]}
+      ] }
     end
   end
 end

--- a/app/reports/spree/cart_updations_report.rb
+++ b/app/reports/spree/cart_updations_report.rb
@@ -12,22 +12,22 @@ module Spree
 
     def generate
       SpreeAdminInsights::ReportDb[:spree_cart_events___cart_events].
-      join(:spree_variants___variants, id: :variant_id).
-      join(:spree_products___products, id: :product_id).
-      where(activity: 'update').
-      where(cart_events__created_at: @start_date..@end_date). #filter by params
-      group(:variant_id).
-      order(sortable_sequel_expression)
+        join(:spree_variants___variants, id: :variant_id).
+        join(:spree_products___products, id: :product_id).
+        where(activity: 'update').
+        where(cart_events__created_at: @start_date..@end_date).#filter by params
+        group(:variant_id, :variants__sku, :products__name).
+        order(sortable_sequel_expression)
     end
 
     def select_columns(dataset)
-      dataset.select{[
+      dataset.select { [
         products__name.as(product_name),
-        Sequel.as(IF(STRCMP(variants__sku, ''), variants__sku, products__name), :sku),
+        Sequel.as(Sequel.lit("CASE variants.sku WHEN '' THEN products.name ELSE variants.sku END"), :sku),
         Sequel.as(count(:products__name), :updations),
-        Sequel.as(sum(IF(cart_events__quantity >= 0, cart_events__quantity, 0)), :quantity_increase),
-        Sequel.as(sum(IF(cart_events__quantity <= 0, cart_events__quantity, 0)), :quantity_decrease)
-      ]}
+        Sequel.as(sum(Sequel.lit("CASE WHEN cart_events.quantity >= 0 THEN cart_events.quantity ELSE 0 END")), :quantity_increase),
+        Sequel.as(sum(Sequel.lit("CASE WHEN cart_events.quantity <= 0 THEN cart_events.quantity ELSE 0 END")), :quantity_decrease)
+      ] }
     end
   end
 end

--- a/app/reports/spree/payment_method_transactions_report.rb
+++ b/app/reports/spree/payment_method_transactions_report.rb
@@ -16,13 +16,13 @@ module Spree
       select{[
         Sequel.as(payment_methods__name, :payment_method_name),
         Sequel.as(payments__amount, :payment_amount),
-        Sequel.as(MONTHNAME(:payments__created_at), :month_name),
-        Sequel.as(MONTH(:payments__created_at), :number),
-        Sequel.as(YEAR(:payments__created_at), :year)
+        Sequel.as(DBUtils.month_name(:payments__created_at), :month_name),
+        Sequel.as(DBUtils.month_number(:payments__created_at), :number),
+        Sequel.as(DBUtils.year(:payments__created_at), :year)
       ]}
 
       group_by_months = SpreeAdminInsights::ReportDb[payments].
-      group(:months_name, :payment_method_name).
+      group(:months_name, :payment_method_name, :t1__year, :t1__number).
       order(:year, :number).
       select{[
         number,
@@ -37,6 +37,7 @@ module Spree
       grouped_by_payment_method_name.each_pair do |name, collection|
         data << fill_missing_values({ payment_method_name: name, payment_amount: 0 }, collection)
       end
+
       @data = data.flatten
     end
 

--- a/app/reports/spree/product_views_to_purchases_report.rb
+++ b/app/reports/spree/product_views_to_purchases_report.rb
@@ -11,33 +11,85 @@ module Spree
     end
 
     def generate(options = {})
-      line_items = ::SpreeAdminInsights::ReportDb[:spree_line_items___line_items].
-      join(:spree_orders___orders, id: :order_id).
-      join(:spree_variants___variants, variants__id: :line_items__variant_id).
-      join(:spree_products___products, products__id: :variants__product_id).
-      where(orders__state: 'complete').
-      where(orders__created_at: @start_date..@end_date). #filter by params
-      select{[line_items__quantity,
-      line_items__id,
-      line_items__variant_id,
-      sum(quantity).as(purchases),
-      products__name.as(product_name),
-      products__id.as(product_id)]}.
-      group(:products__name).as(:line_items)
+      purchases_by_product = ::SpreeAdminInsights::ReportDb[:spree_line_items___line_items]
+                               .join(:spree_variants___variants, id: :variant_id)
+                               .join(:spree_products___products, id: :variants__product_id)
+                               .join(:spree_orders___orders, id: :line_items__order_id)
+                               .where(orders__state: 'complete')
+                               .where(orders__created_at: @start_date..@end_date)
+                               .group(:products__id)
+                               .select { [
+        Sequel.as(Sequel.function(:SUM, :line_items__quantity), :purchases),
+        Sequel.as(:products__name, :product_name),
+        Sequel.as(:products__id, :product_id)
+      ] }.as(:purchases_by_product)
 
-      ::SpreeAdminInsights::ReportDb[line_items].join(:spree_page_events___page_events, page_events__target_id: :product_id).
-      where(page_events__target_type: 'Spree::Product', page_events__activity: 'view').
-      group(:product_name).
-      order(sortable_sequel_expression)
+
+      case DBUtils.adapter
+        when :postgresql
+          generate_postgresql(purchases_by_product)
+        else
+          generate_mysql(purchases_by_product)
+      end
     end
 
     def select_columns(dataset)
-      dataset.select{[
-        product_name,
-        count('*').as(views),
-        purchases,
-        Sequel.as(ROUND(purchases / count('*'), 2), :purchase_to_view_ratio)
-      ]}
+      base_columns = [:product_name, :purchases]
+
+      case DBUtils.adapter
+        when :postgresql
+          dataset.select { base_columns | [
+            :views,
+            Sequel.as(Sequel.lit("ROUND((purchases / views :: NUMERIC), 2)"), :purchase_to_view_ratio)
+          ] }
+        else
+          dataset.select { base_columns | [
+            COUNT('*').as(:views),
+            Sequel.as(Sequel.lit("ROUND(purchases / COUNT('*'), 2)"), :purchase_to_view_ratio)
+          ] }
+      end
+    end
+
+    private
+
+    def generate_postgresql(purchases_by_product)
+      view_events = ::SpreeAdminInsights::ReportDb[:spree_page_events___page_events]
+                      .where(page_events__target_type: 'Spree::Product', page_events__activity: 'view')
+                      .group(:target_id)
+                      .select { [
+        Sequel.as(Sequel.function(:COUNT, '*'), :views),
+        :page_events__target_id
+      ] }.as(:view_events)
+
+      not_ordered_result = ::SpreeAdminInsights::ReportDb[line_items(purchases_by_product)]
+                             .join(::SpreeAdminInsights::ReportDb[view_events], target_id: :product_id)
+                             .distinct(:product_id)
+
+      ::SpreeAdminInsights::ReportDb[not_ordered_result].order(sortable_sequel_expression)
+    end
+
+    def generate_mysql(purchases_by_product)
+      ::SpreeAdminInsights::ReportDb[line_items(purchases_by_product)]
+        .join(:spree_page_events___page_events, page_events__target_id: :product_id)
+        .where(page_events__target_type: 'Spree::Product', page_events__activity: 'view')
+        .group(:product_id)
+        .order(sortable_sequel_expression)
+    end
+
+    def line_items(purchases_by_product)
+      line_items = ::SpreeAdminInsights::ReportDb[purchases_by_product]
+                     .join(:spree_variants___variants, product_id: :purchases_by_product__product_id)
+                     .join(:spree_line_items___line_items, variant_id: :variants__id)
+
+      columns = [:line_items__quantity, :line_items__id, :line_items__variant_id,
+        :purchases_by_product__purchases, :purchases_by_product__product_name, :purchases_by_product__product_id]
+
+      case DBUtils.adapter
+        when :postgresql
+          line_items.distinct(:purchases_by_product__product_id).select(*columns).as(:line_items)
+        else
+          line_items.group(:purchases_by_product__product_id).select(*columns).as(:line_items)
+      end
     end
   end
 end

--- a/app/reports/spree/report.rb
+++ b/app/reports/spree/report.rb
@@ -1,6 +1,5 @@
 module Spree
   class Report
-
     attr_accessor :sortable_attribute, :sortable_type
 
     def no_pagination?
@@ -14,7 +13,7 @@ module Spree
     def initialize(options)
       @search = options.fetch(:search, {})
       start_date = @search[:start_date]
-      @start_date = start_date.present? ? Date.parse(start_date) :  Date.new(Date.current.year)
+      @start_date = start_date.present? ? Date.parse(start_date) : Date.new(Date.current.year)
 
       end_date = @search[:end_date]
       # 1.day is added to date so that we can get current date records
@@ -37,9 +36,11 @@ module Spree
 
     def fill_missing_values(default_object, incomplete_result_set)
       complete_result_set = []
-      year_month_list = (@start_date..@end_date).map{ |date| [date.year, date.month] }.uniq
+      year_month_list = (@start_date..@end_date).map { |date| [date.year, date.month] }.uniq
       year_month_list.each do |year_month|
-        index = incomplete_result_set.index { |obj| obj[:year] == year_month.first && obj[:number] == year_month.second }
+        index = incomplete_result_set.index do |obj|
+          obj[:year].to_s == year_month.first.to_s && obj[:number].to_s == year_month.second.to_s
+        end
         if index
           complete_result_set.push(incomplete_result_set[index])
         else
@@ -56,7 +57,5 @@ module Spree
         charts: []
       }
     end
-
-
   end
 end

--- a/app/reports/spree/returned_products_report.rb
+++ b/app/reports/spree/returned_products_report.rb
@@ -17,14 +17,14 @@ module Spree
       join(:spree_variants, spree_variants__id: :variant_id).
       join(:spree_products, id: :product_id).
       where(spree_return_items__created_at: @start_date..@end_date).
-      group(:variant_id).
+      group(:variant_id, :spree_variants__sku, :spree_products__name).
       order(sortable_sequel_expression)
     end
 
     def select_columns(dataset)
       dataset.select{[
         spree_products__name.as(product_name),
-        Sequel.as(IF(STRCMP(spree_variants__sku, ''), spree_variants__sku, spree_products__name), :sku),
+        Sequel.as(Sequel.lit("CASE spree_variants.sku WHEN '' THEN spree_products.name ELSE spree_variants.sku END"), :sku),
         Sequel.as(count(:variant_id), :return_count)
       ]}
     end

--- a/app/reports/spree/sales_tax_report.rb
+++ b/app/reports/spree/sales_tax_report.rb
@@ -18,13 +18,13 @@ module Spree
         Sequel.as(abs(adjustments__amount), :sales_tax),
         Sequel.as(:zones__id, :zone_id),
         :zones__name___zone_name,
-        Sequel.as(MONTHNAME(:adjustments__created_at), :month_name),
-        Sequel.as(YEAR(:adjustments__created_at), :year),
-        Sequel.as(MONTH(:adjustments__created_at), :number)
+        Sequel.as(DBUtils.month_name(:adjustments__created_at), :month_name),
+        Sequel.as(DBUtils.year(:adjustments__created_at), :year),
+        Sequel.as(DBUtils.month_number(:adjustments__created_at), :number)
       ]}
 
       group_by_months = SpreeAdminInsights::ReportDb[adjustments_with_month_name].
-      group(:months_name, :zone_id).
+      group(:months_name, :zone_id, :zone_name, :year, :number).
       order(:year, :number).
       select{[
         number,

--- a/app/reports/spree/shipping_cost_report.rb
+++ b/app/reports/spree/shipping_cost_report.rb
@@ -10,23 +10,23 @@ module Spree
 
     def generate(options = {})
       order_join_shipments = SpreeAdminInsights::ReportDb[:spree_orders___orders].
-      exclude(completed_at: nil).
-      join(:spree_shipments___shipments, order_id: :id).
-      where(orders__created_at: @start_date..@end_date). #filter by params
-      select{[
+        exclude(completed_at: nil).
+        join(:spree_shipments___shipments, order_id: :id).
+        where(orders__created_at: @start_date..@end_date).#filter by params
+      select { [
         Sequel.as(shipments__id, :shipment_id),
         Sequel.as(orders__shipment_total, :shipping_charge),
         Sequel.as(shipments__order_id, :order_id),
         Sequel.as(orders__total, :order_total),
-        Sequel.as(MONTHNAME(:orders__created_at), :month_name),
-        Sequel.as(MONTH(:orders__created_at), :number),
-        Sequel.as(YEAR(:orders__created_at), :year)
-      ]}.as(:order_shipment)
+        Sequel.as(DBUtils.month_name(:orders__created_at), :month_name),
+        Sequel.as(DBUtils.month_number(:orders__created_at), :number),
+        Sequel.as(DBUtils.year(:orders__created_at), :year)
+      ] }.as(:order_shipment)
 
-      order_shipment_join_shipment_rates = SpreeAdminInsights::ReportDb[order_join_shipments].
-      join(:spree_shipping_rates___shipping_rates, shipment_id: :order_shipment__shipment_id).
-      where(selected: true).
-      select{[
+      order_shipment_rates = SpreeAdminInsights::ReportDb[order_join_shipments].
+        join(:spree_shipping_rates___shipping_rates, shipment_id: :order_shipment__shipment_id).
+        where(selected: true).
+        select { [
         order_id,
         shipping_charge,
         order_total,
@@ -34,36 +34,20 @@ module Spree
         month_name,
         number,
         year,
-        Sequel.as(concat(month_name, ' ', IFNULL(year, 2016)), :months_name),
-      ]}.as(:order_shipment_rates)
+        Sequel.as(concat(month_name, ' ', COALESCE(year, '2016')), :months_name),
+      ] }.as(:order_shipment_rates)
 
-      revenue_table = SpreeAdminInsights::ReportDb[order_shipment_join_shipment_rates].
-      group(:months_name).
-      select{[
-        Sequel.as(concat(month_name, ' ', IFNULL(year, 2016)), :months_name),
-        Sequel.as(SUM(order_total), :revenue),
-        order_id
-      ]}
+      revenue_table = SpreeAdminInsights::ReportDb[order_shipment_rates].
+        group(:order_shipment_rates__month_name, :order_shipment_rates__year).
+        select { [
+        Sequel.as(concat(month_name, ' ', COALESCE(year, '2016')), :months_name),
+        Sequel.as(SUM(order_total), :revenue)
+      ] }.as(:revenue_table)
 
-      group_by_months = SpreeAdminInsights::ReportDb[order_shipment_join_shipment_rates].
-      join(:spree_shipping_methods, id: :order_shipment_rates__shipping_method_id).
-      join(revenue_table, months_name: :order_shipment_rates__months_name).
-      group(:months_name, :spree_shipping_methods__id).
-      order(:year, :number).
-      select{[
-        order_shipment_rates__order_id,
-        spree_shipping_methods__id,
-        Sequel.as(SUM(shipping_charge), :shipping_charge),
-        revenue,
-        shipping_method_id,
-        Sequel.as(concat(month_name, ' ', IFNULL(year, 2016)), :months_name),
-        Sequel.as(ROUND((SUM(shipping_charge) / revenue) * 100, 2), :shipping_cost_percentage),
-        number,
-        year,
-        name
-      ]}
+      grouped_by_method_name = grouped_by_months(order_shipment_rates, revenue_table).all.group_by do |record|
+        record[:name]
+      end
 
-      grouped_by_method_name = group_by_months.all.group_by { |record| record[:name] }
       data = []
       grouped_by_method_name.each_pair do |name, collection|
         data << fill_missing_values({ shipping_charge: 0, revenue: 0, name: name, shipping_cost_percentage: 0 }, collection)
@@ -100,10 +84,10 @@ module Spree
               },
               tooltip: { valueSuffix: '%' },
               legend: {
-                  layout: 'vertical',
-                  align: 'right',
-                  verticalAlign: 'middle',
-                  borderWidth: 0
+                layout: 'vertical',
+                align: 'right',
+                verticalAlign: 'middle',
+                borderWidth: 0
               },
               series: chart_data[:collection].map { |key, value| { name: key, data: value.map { |r| r[:shipping_cost_percentage].to_f } } }
             }
@@ -114,6 +98,72 @@ module Spree
 
     def select_columns(dataset)
       dataset
+    end
+
+    private
+
+    def grouped_by_months(order_shipment_rates, revenue_table)
+      case DBUtils.adapter
+        when :postgresql
+          grouped_by_months_postgresql(order_shipment_rates, revenue_table)
+        else
+          grouped_by_months_mysql(order_shipment_rates, revenue_table)
+      end
+    end
+
+    def grouped_by_months_postgresql(order_shipment_rates, revenue_table)
+      shipping_charge_table = SpreeAdminInsights::ReportDb[order_shipment_rates]
+                                .group(:revenue_table__months_name, :spree_shipping_methods__id)
+                                .join(:spree_shipping_methods, id: :order_shipment_rates__shipping_method_id)
+                                .join(revenue_table, months_name: :order_shipment_rates__months_name)
+                                .select { [
+        Sequel.as(SUM(:shipping_charge), :shipping_charge),
+        :revenue_table__months_name,
+        :spree_shipping_methods__id
+      ] }.as(:shipping_charge_table)
+
+      unordered_group_by_months = SpreeAdminInsights::ReportDb[order_shipment_rates]
+                                    .join(:spree_shipping_methods, id: :order_shipment_rates__shipping_method_id)
+                                    .join(shipping_charge_table, months_name: :order_shipment_rates__months_name)
+                                    .join(revenue_table, months_name: :order_shipment_rates__months_name)
+                                    .distinct(:order_shipment_rates__months_name, :spree_shipping_methods__id)
+                                    .select { [
+        :order_shipment_rates__order_id,
+        :spree_shipping_methods__id,
+        :shipping_charge_table__shipping_charge,
+        :revenue_table__revenue,
+        :shipping_method_id,
+        Sequel.as(concat(month_name, ' ', COALESCE(year, '2016')), :months_name),
+        Sequel.as(
+          Sequel.lit("ROUND((shipping_charge_table.shipping_charge / revenue_table.revenue :: NUMERIC) * 100, 2)"),
+          :shipping_cost_percentage
+        ),
+        :number,
+        :year,
+        :name
+      ] }
+
+      SpreeAdminInsights::ReportDb[unordered_group_by_months].order(:year, :number)
+    end
+
+    def grouped_by_months_mysql(order_shipment_rates, revenue_table)
+      SpreeAdminInsights::ReportDb[order_shipment_rates].
+        join(:spree_shipping_methods, id: :order_shipment_rates__shipping_method_id).
+        join(revenue_table, months_name: :order_shipment_rates__months_name).
+        group(:months_name, :spree_shipping_methods__id).
+        order(:year, :number).
+        select { [
+        order_shipment_rates__order_id,
+        spree_shipping_methods__id,
+        Sequel.as(SUM(shipping_charge), :shipping_charge),
+        revenue,
+        shipping_method_id,
+        Sequel.as(concat(month_name, ' ', COALESCE(year, '2016')), :months_name),
+        Sequel.as(ROUND((SUM(shipping_charge) / revenue) * 100, 2), :shipping_cost_percentage),
+        number,
+        year,
+        name
+      ] }
     end
   end
 end

--- a/app/reports/spree/unique_purchases_report.rb
+++ b/app/reports/spree/unique_purchases_report.rb
@@ -17,13 +17,13 @@ module Spree
       join(:spree_products___products, products__id: :variants__product_id).
       where(orders__state: 'complete').
       where(orders__completed_at: @start_date..@end_date). #filter by params
-      group(:variant_id).
+      group(:variant_id, :variants__sku, :products__name).
       order(sortable_sequel_expression)
     end
 
     def select_columns(dataset)
       dataset.select{[
-        Sequel.as(IF(STRCMP(variants__sku, ''), variants__sku, products__name), :sku),
+        Sequel.as(Sequel.lit("CASE variants.sku WHEN '' THEN products.name ELSE variants.sku END"), :sku),
         products__name.as(product_name),
         sum(quantity).as(sold_count),
         (count(distinct orders__user_id) + count(orders__id) - count(orders__user_id)).as(users)

--- a/app/reports/spree/user_pool_report.rb
+++ b/app/reports/spree/user_pool_report.rb
@@ -15,40 +15,40 @@ module Spree
       where(users__created_at: @start_date..@end_date).
       select{[
         id.as(:user_id),
-        Sequel.as(YEAR(:users__created_at), :year),
-        Sequel.as(MONTHNAME(:users__created_at), :month_name),
-        Sequel.as(MONTH(:users__created_at), :number)
+        Sequel.as(DBUtils.year(:users__created_at), :year),
+        Sequel.as(DBUtils.month_name(:users__created_at), :month_name),
+        Sequel.as(DBUtils.month_number(:users__created_at), :number)
       ]}
 
       group_new_sign_ups_by_months = SpreeAdminInsights::ReportDb[new_sign_ups].
-      group(:months_name).
+      group(:months_name, :t1__year, :t1__number).
       order(:year, :number).
       select{[
         number,
         year,
-        Sequel.as(concat(month_name, ' ', IFNULL(year, 2016)), :months_name),
+        Sequel.as(concat(month_name, ' ', COALESCE(year, '2016')), :months_name),
         Sequel.as(0, :guest_users),
         Sequel.as(0, :active_users),
-        Sequel.as(IFNULL(COUNT(user_id), 0), :new_sign_ups)
+        Sequel.as(COALESCE(COUNT(user_id), 0), :new_sign_ups)
       ]}
 
       vistors = SpreeAdminInsights::ReportDb[:spree_page_events___page_events].
       where(page_events__created_at: @start_date..@end_date).
       select{[
-        Sequel.as(YEAR(:page_events__created_at), :year),
-        Sequel.as(MONTHNAME(:page_events__created_at), :month_name),
-        Sequel.as(MONTH(:page_events__created_at), :number),
+        Sequel.as(DBUtils.year(:page_events__created_at), :year),
+        Sequel.as(DBUtils.month_name(:page_events__created_at), :month_name),
+        Sequel.as(DBUtils.month_number(:page_events__created_at), :number),
         Sequel.as(actor_id, :user),
         Sequel.as(session_id, :session)
       ]}
 
       visitors_by_months = SpreeAdminInsights::ReportDb[vistors].
-      group(:months_name).
+      group(:months_name, :t1__year, :t1__number).
       order(:year, :number).
       select{[
         number,
         year,
-        Sequel.as(concat(month_name, ' ', IFNULL(year, 2016)), :months_name),
+        Sequel.as(concat(month_name, ' ', COALESCE(year, '2016')), :months_name),
         Sequel.as((COUNT(DISTINCT session) - COUNT(DISTINCT user)), :guest_users),
         Sequel.as(COUNT(DISTINCT user), :active_users),
         Sequel.as(0, :new_sign_ups)
@@ -58,7 +58,7 @@ module Spree
       union_of_stats = group_new_sign_ups_by_months.union(visitors_by_months)
 
       union_stats = SpreeAdminInsights::ReportDb[union_of_stats].
-      group(:months_name).
+      group(:months_name, :t1__year, :t1__number).
       order(:year, :number).
       select{[
         months_name,

--- a/app/reports/spree/users_not_converted_report.rb
+++ b/app/reports/spree/users_not_converted_report.rb
@@ -12,18 +12,20 @@ module Spree
     end
 
     def generate(options = {})
-      SpreeAdminInsights::ReportDb[:spree_users___users].
-      left_join(:spree_orders___orders, user_id: :id).
-      where(orders__completed_at: nil, orders__number: nil).
-      where(users__created_at: @start_date..@end_date).where(Sequel.ilike(:users__email, @email_cont)). #filter by params
-      order(sortable_sequel_expression)
+      users = SpreeAdminInsights::ReportDb[:spree_users___users].
+        left_join(:spree_orders___orders, user_id: :id).
+        where(orders__completed_at: nil, orders__number: nil).
+        where(users__created_at: @start_date..@end_date).where(Sequel.ilike(:users__email, @email_cont)) #filter by params
+
+      return users if sortable_sequel_expression.expression.nil?
+      users.order(sortable_sequel_expression)
     end
 
     def select_columns(dataset)
-      dataset.select{[
+      dataset.select { [
         users__email.as(user_email),
         users__created_at.as(signup_date)
-      ]}
+      ] }
     end
   end
 end

--- a/app/reports/spree/users_who_recently_purchased_report.rb
+++ b/app/reports/spree/users_who_recently_purchased_report.rb
@@ -12,29 +12,78 @@ module Spree
     end
 
     def generate(options = {})
-      all_orders_with_users = SpreeAdminInsights::ReportDb[:spree_users___users].
-      left_join(:spree_orders___orders, user_id: :id).
-      where(orders__completed_at: @start_date..@end_date).
-      where(Sequel.ilike(:users__email, @email_cont)).
-      order(Sequel.desc(:orders__completed_at)).
-      select(
-        :users__email___user_email,
-        :orders__number___last_purchased_order_number,
-        :orders__completed_at___last_purchase_date,
-      ).as(:all_orders_with_users)
-
-      SpreeAdminInsights::ReportDb[all_orders_with_users].
-      group(:all_orders_with_users__user_email).
-      order(sortable_sequel_expression)
+      case DBUtils.adapter
+        when :postgresql
+          generate_from_postgresql
+        else
+          generate_from_mysql
+      end
     end
 
     def select_columns(dataset)
-      dataset.select{[
+      case DBUtils.adapter
+        when :postgresql
+          select_columns_postgresql(dataset)
+        else
+          select_columns_mysql(dataset)
+      end
+    end
+
+    private
+
+    def generate_from_postgresql
+      all_orders_with_users = SpreeAdminInsights::ReportDb[:spree_orders___orders]
+                                .join(:spree_users___users, id: :user_id)
+                                .where(orders__completed_at: @start_date..@end_date)
+                                .where(Sequel.ilike(:users__email, @email_cont))
+                                .select(Sequel.lit("COUNT(*) AS purchase_count"))
+                                .select_append { [
+        Sequel.as(:users__email, :user_email),
+        Sequel.as(Sequel.function(:MIN, :orders__completed_at), :last_purchase_date)
+      ] }.group(:users__email).order(Sequel.desc(:last_purchase_date))
+                                .as(:all_orders_with_users)
+
+      SpreeAdminInsights::ReportDb[all_orders_with_users]
+        .left_join(:spree_orders___orders, email: :user_email)
+        .distinct(:user_email)
+        .select { [Sequel.as(:all_orders_with_users, :user_email)] }
+    end
+
+    def select_columns_postgresql(dataset)
+      results = dataset.select { [
+        :user_email,
+        :all_orders_with_users__purchase_count,
+        :all_orders_with_users__last_purchase_date,
+        Sequel.as(:orders__number, :last_purchased_order_number)
+      ] }
+
+      SpreeAdminInsights::ReportDb[results].order(sortable_sequel_expression)
+    end
+
+    def generate_from_mysql
+      all_orders_with_users = SpreeAdminInsights::ReportDb[:spree_users___users].
+        left_join(:spree_orders___orders, user_id: :id).
+        where(orders__completed_at: @start_date..@end_date).
+        where(Sequel.ilike(:users__email, @email_cont)).
+        order(Sequel.desc(:orders__completed_at)).
+        select(
+          :users__email___user_email,
+          :orders__number___last_purchased_order_number,
+          :orders__completed_at___last_purchase_date,
+        ).as(:all_orders_with_users)
+
+      SpreeAdminInsights::ReportDb[all_orders_with_users].
+        group(:all_orders_with_users__user_email).
+        order(sortable_sequel_expression)
+    end
+
+    def select_columns_mysql(dataset)
+      dataset.select { [
         all_orders_with_users__user_email,
         all_orders_with_users__last_purchased_order_number,
         all_orders_with_users__last_purchase_date,
         count(all_orders_with_users__user_email).as(purchase_count)
-      ]}
+      ] }
     end
   end
 end

--- a/lib/d_b_utils.rb
+++ b/lib/d_b_utils.rb
@@ -1,0 +1,42 @@
+module DBUtils
+  def self.month_name(date_field)
+    case adapter
+      when :postgresql
+        date_format(date_field, 'Month')
+      else
+        Sequel.function(:MONTHNAME, date_field)
+    end
+  end
+
+  def self.month_number(date_field)
+    case adapter
+      when :postgresql
+        date_format(date_field, 'fmMM')
+      else
+        Sequel.function(:MONTH, date_field)
+    end
+  end
+
+  def self.year(date_field)
+    case adapter
+      when :postgresql
+        date_format(date_field, 'YYYY')
+      else
+        Sequel.function(:YEAR, date_field)
+    end
+  end
+
+  def self.date_format(date_field, format)
+    case adapter
+      when :postgresql
+        Sequel.function(:TO_CHAR, date_field, format)
+      else
+        Sequel.function(:DATE_FORMAT, date_field, format)
+    end
+  end
+
+  def self.adapter
+    @adapter ||= (ActiveRecord::Base.configurations[Rails.env] ||
+      Rails.configuration.database_configuration[Rails.env])['adapter'].to_sym
+  end
+end

--- a/lib/spree_admin_insights.rb
+++ b/lib/spree_admin_insights.rb
@@ -1,2 +1,3 @@
 require 'spree_core'
+require 'd_b_utils'
 require 'spree_admin_insights/engine'


### PR DESCRIPTION
Adds support for PostgresSQL.

Some expressions are rewritten so they work both in MySQL and PostgresSQL.
Some queries are rewritten so the query is built especially for postresql, it's mostly because of how Group By, aggregate functions and DISTINCT ON work there.

DBUtils module that can translate function calls matched for database.