### PR TITLE
Promotion Analysis Fixes

### DIFF
--- a/app/reports/spree/annual_promotional_cost_report.rb
+++ b/app/reports/spree/annual_promotional_cost_report.rb
@@ -2,7 +2,7 @@ module Spree
   class AnnualPromotionalCostReport < Spree::PromotionalCostReport
     DEFAULT_SORTABLE_ATTRIBUTE = :promotion_name
     HEADERS = { promotion_name: :string, usage_count: :integer, promotion_discount: :integer }
-    SEARCH_ATTRIBUTES = {}
+    SEARCH_ATTRIBUTES = { start_date: :promotion_applied_from, end_date: :promotion_applied_till }
     SORTABLE_ATTRIBUTES = []
 
     def generate

--- a/app/reports/spree/promotional_cost_report.rb
+++ b/app/reports/spree/promotional_cost_report.rb
@@ -2,7 +2,7 @@ module Spree
   class PromotionalCostReport < Spree::Report
     DEFAULT_SORTABLE_ATTRIBUTE = :promotion_name
     HEADERS = { promotion_name: :string, usage_count: :integer, promotion_discount: :integer, promotion_code: :string, promotion_start_date: :date, promotion_end_date: :date }
-    SEARCH_ATTRIBUTES = { start_date: :promotion_created_from, end_date: :promotion_created_till }
+    SEARCH_ATTRIBUTES = { start_date: :promotion_applied_from, end_date: :promotion_applied_till }
     SORTABLE_ATTRIBUTES = [:promotion_name, :usage_count, :promotion_discount, :promotion_code, :promotion_start_date, :promotion_end_date]
 
     def no_pagination?


### PR DESCRIPTION
## Promotion Analysis
This section has two reports:
- Promotional Cost
- Annual Promotional Cost

The **date filters** in these two reports do not have proper labels.
- In `Promotional Cost` report, `PROMOTION CREATED FROM` and `PROMOTION CREATED TILL` labels are being used. 

![promotional cost report](https://cloud.githubusercontent.com/assets/21332195/25999780/1248434e-3744-11e7-99ec-9f69f44ac5f7.png)

- In `Annual Promotional Cost` report, no labels are present.

![annual promotional cost report](https://cloud.githubusercontent.com/assets/21332195/25999781/124affb2-3744-11e7-92f4-af151a60fab0.png)

These dates filters the result on **adjustment's created_at** field. Hence, it is misleading to the admin understand the results as per the applied filters.

## Fix
`PROMOTION APPLIED FROM` and `PROMOTION APPLIED TILL` labels should be used. This makes the admin understand that he/she can filter the promotion results according to the time period they are applied on any order.
